### PR TITLE
Move over to new Azure SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,14 @@ urlFragment: redundant-storage-javascript
 
 # How to utilize redundant Azure Blob Storage with JavaScript
 
-This sample shows how to utilize redundant Azure Blob Storage with JavaScript.
-
-If you don't have a Microsoft Azure subscription, you can get a [free account] before you begin.
-
 ## SDK Versions
-
 In this sample, you will find the following folders:
 
-* **[azure-sdk-for-js-storage-blob-redundant-v10]** - references [Storage Blob SDK v10]
-* **[azure-sdk-for-js-storage-blob-redundant-v12]** - references [Storage Blob SDK v12]
+* **azure-sdk-for-js-storage-blob-redundant-v10** - references Storage Blob SDK v10
+* **azure-sdk-for-js-storage-blob-redundant-v12** - references Storage Blob SDK v12
 
 ## Prerequisites
+If you don't have a Microsoft Azure subscription, you can get a [free account] before you begin.
 
 Following prerequisites are needed to run this sample and verify that files are downloaded from primary storage:
 
@@ -65,18 +61,15 @@ Steps to test secondary storage access:
     ```
 
 ## This Sample shows how to do following operations of Storage Blobs
-
 * Create a storage account.
 * Create a container.
 * Upload a file to blockblob.
 * Enter D to download the file or Q to quit.
 
 ## How it works
-
 This sample creates a new container in blob storage and uploads a sample file into it called `HelloWorld.jpg`. It then checks secondary storage repeatedly until both the container and file have been replicated. The user can then enter D to download the file or Q to quit. If the file is successfully downloaded, the sample indicates whether it came from primary or secondary storage. When the user quits the sample, it deletes the container and file. 
 
 ## How to run the sample
-
 To run this sample and verify that files are downloaded from primary storage, we are going to:
 
 1. Launch the sample from the console window by running `node index.js`.
@@ -108,16 +101,11 @@ To test secondary storage access, we are going to:
 4. Press Q to quit the sample and delete the container and file from storage.
 
 ## More information
-
 - [About Azure Storage Accounts]
 - [Designing HA Apps with RA-GRS Storage]
 - [Azure Storage Replication]
 
 <!-- LINKS -->
-[azure-sdk-for-js-storage-blob-redundant-v10]: https://github.com/Azure-Samples/azure-sdk-for-js-storage-blob-redundant/tree/master/azure-sdk-for-js-storage-blob-redundant-v10
-[azure-sdk-for-js-storage-blob-redundant-v12]: https://github.com/Azure-Samples/azure-sdk-for-js-storage-blob-redundant/tree/master/azure-sdk-for-js-storage-blob-redundant-v12
-[Storage Blob SDK v10]: https://www.npmjs.com/package/@azure/storage-blob/v/10.3.0
-[Storage Blob SDK v12]: https://www.npmjs.com/package/@azure/storage-blob/v/12.0.0
 [About Azure Storage Accounts]: https://docs.microsoft.com/azure/storage/storage-create-storage-account
 [Designing HA Apps with RA-GRS Storage]: https://docs.microsoft.com/azure/storage/common/storage-designing-ha-apps-with-ragrs
 [Azure Storage Replication]: https://docs.microsoft.com/azure/storage/storage-redundancy


### PR DESCRIPTION
**Purpose**
---------------------------------------------------------------------------------------------------------------
Move over this sample to new Azure SDK:

1. Move the original file to azure-sdk-for-js-storage-blob-redundant-v10 folder
2. Add folder azure-sdk-for-js-storage-blob-redundant-v12 for the sample referenced to the new SDK
3. Add three sections to the readme:
   - Prerequisites which tell user what info we need
   - SDK Versions
   - UrlFragment

**What old sample do**
---------------------------------------------------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/20970631/64946887-6a3c0580-d8a6-11e9-9f43-1153af1c4155.png)

**What can be updated to v12:**
---------------------------------------------------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/20970631/64947070-cf8ff680-d8a6-11e9-9c46-63064abf5d9f.png)